### PR TITLE
Remove associate_public_ip_address from being a factor when creating …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LOCAL_OS_AWS_PROFILE :="bb-dev-deploymaster"
 LOCAL_OS_AWS_REGION := us-east-1
 
 TF_PWD_DIR := $(shell pwd)
-TF_VER := 0.12.20
+TF_VER := 0.12.24
 TF_PWD_CONT_DIR := "/go/src/project/"
 TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
 TF_DOCKER_IMAGE := binbash/terraform-resources

--- a/dns.tf
+++ b/dns.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "main_private" {
-  count = length(var.dns_records_internal_hosted_zone) > 0 && var.associate_public_ip_address == true ? length(var.dns_records_internal_hosted_zone) : 0
+  count = length(var.dns_records_internal_hosted_zone) > 0 ? length(var.dns_records_internal_hosted_zone) : 0
 
   zone_id = lookup(element(var.dns_records_internal_hosted_zone, count.index), "zone_id", null)
   name    = lookup(element(var.dns_records_internal_hosted_zone, count.index), "name", null)


### PR DESCRIPTION
…private DNS records

## what
* Remove associate_public_ip_address from being a factor when creating private DNS records

## why
* Private DNS records should not depend on whether the instance has a public IP or not.

## references
* closes #16

