### PR TITLE
BBL-192 | taging AMI to approve and pass aws-config approved-amis-by-tag rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Personally we have seen the need of creating a similar set of such resources
 | root\_block\_device | Customize details about the root block device of the instance. See Block Devices below for details | `list(map(string))` | `[]` | no |
 | root\_device\_backup\_tag | EC2 Root Block Device backup tag | `string` | `"True"` | no |
 | security\_group\_rules | A list of security group rules | `list(any)` | `[]` | no |
+| tagApprovedAMIvalue | Tags | `string` | `"false"` | no |
 | tags | Tags | `map(string)` | `{}` | no |
 | user\_data | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user\_data\_base64 instead. | `string` | `null` | no |
 | user\_data\_base64 | Can be used instead of user\_data to pass base64-encoded binary data directly. Use this instead of user\_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. | `string` | `null` | no |

--- a/instances.tf
+++ b/instances.tf
@@ -16,7 +16,12 @@ data "aws_ami" "ubuntu_linux" {
   //  match the search above. So, in order to be safe, you need to verify that the owner of the ami is '099720109477'.
   owners = [var.aws_ami_os_owner] # Canonical
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      ApprovedAMI = var.tagApprovedAMIvalue
+    },
+  )
 }
 
 resource "aws_instance" "main" {

--- a/instances.tf
+++ b/instances.tf
@@ -15,6 +15,8 @@ data "aws_ami" "ubuntu_linux" {
   //  Any user can register an AMI under any name. Nothing prevents a malicious user from registering an AMI that would
   //  match the search above. So, in order to be safe, you need to verify that the owner of the ami is '099720109477'.
   owners = [var.aws_ami_os_owner] # Canonical
+
+  tags        = var.tags
 }
 
 resource "aws_instance" "main" {

--- a/instances.tf
+++ b/instances.tf
@@ -16,7 +16,7 @@ data "aws_ami" "ubuntu_linux" {
   //  match the search above. So, in order to be safe, you need to verify that the owner of the ami is '099720109477'.
   owners = [var.aws_ami_os_owner] # Canonical
 
-  tags        = var.tags
+  tags = var.tags
 }
 
 resource "aws_instance" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tagApprovedAMIvalue" {
+  type        = string
+  description = "Tags"
+  default     = "false"
+}
+
 variable "root_device_backup_tag" {
   type        = string
   description = "EC2 Root Block Device backup tag"


### PR DESCRIPTION
### What?
#### Commits on Oct 21, 2020
- @exequielrafaela - BBL-192 | taggin ami to approve and pass aws-config approved-amis-by-tag rule - e782a03

### Why? 
- Tagging AMIs by default https://docs.aws.amazon.com/config/latest/developerguide/approved-amis-by-tag.html
- We're trusting that the AWS Operator has wisely choose his AMI based on a secure perspective.