### PR TITLE
Feature/BBL-440 | makefile improvement + ci pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             pip install pre-commit
             curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
-            mv ./terraform-docs /some-dir-in-your-PATH/terraform-docs
+            mv ./terraform-docs /usr/local/bin/terraform-docs
             make pre-commit
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
 #
 orbs:
   sumologic: circleci/sumologic@1.0.6
+  slack: circleci/slack@4.1.1
 
 #
 # Jobs workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,24 @@ jobs:
       - run:
           name: test1-terraform-format
           command: |
+            #
+            # Install pre-commit
             pip install pre-commit
+            #
+            # Install terraform
+            sudo apt-get install unzip
+            wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/terraform_${TERRAFORM_VER}_linux_amd64.zip
+            unzip terraform_${TERRAFORM_VER}_linux_amd64.zip
+            sudo mv terraform /usr/local/bin/
+            terraform --version
+            #
+            # Install terraform-docs
+            sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
             curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
+            #
+            # Run tests
             make pre-commit
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,9 @@ jobs:
 
       - run:
           name: test1-terraform-format
-          command: make format-check
+          command: |
+          pip install pre-commit
+          make pre-commit
 
       - run:
           name: Install awscli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
           name: test1-terraform-format
           command: |
             pip install pre-commit
+            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
+            chmod +x ./terraform-docs
+            mv ./terraform-docs /some-dir-in-your-PATH/terraform-docs
             make pre-commit
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
       - run:
           name: test1-terraform-format
           command: |
-          pip install pre-commit
-          make pre-commit
+            pip install pre-commit
+            make pre-commit
 
       - run:
           name: Install awscli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             pip install pre-commit
             curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
-            mv ./terraform-docs /usr/local/bin/terraform-docs
+            sudo mv ./terraform-docs /usr/local/bin/terraform-docs
             make pre-commit
 
       - run:
@@ -179,12 +179,12 @@ workflows:
             branches:
              ignore: # only branches matching the below regex filters will run
                - master
-      - test-e2e-terratests:
-          context: binbashar-org-global-context
-          filters:
-            branches:
-             ignore: # only branches matching the below regex filters will run
-               - master
+#      - test-e2e-terratests:
+#          context: binbashar-org-global-context
+#          filters:
+#            branches:
+#             ignore: # only branches matching the below regex filters will run
+#               - master
       - release-version-with-changelog:
           context: binbashar-org-global-context
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             git update-index --assume-unchanged "Makefile"
 
       - run:
-          name: test1-terraform-format
+          name: test1-terraform-format-and-docs
           command: |
             #
             # Install pre-commit
@@ -193,12 +193,12 @@ workflows:
             branches:
              ignore: # only branches matching the below regex filters will run
                - master
-#      - test-e2e-terratests:
-#          context: binbashar-org-global-context
-#          filters:
-#            branches:
-#             ignore: # only branches matching the below regex filters will run
-#               - master
+      - test-e2e-terratests:
+          context: binbashar-org-global-context
+          filters:
+            branches:
+             ignore: # only branches matching the below regex filters will run
+               - master
       - release-version-with-changelog:
           context: binbashar-org-global-context
           filters:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !/.github
 !*.gitkeep
 !*.editorconfig
+!*.pre-commit-config.yaml
 
 # SSH keys #
 ############

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+default_language_version:
+    # force all unspecified python hooks to run python3
+    python: python3
+
+repos:
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: detect-private-key
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: trailing-whitespace
+        args:
+          - --markdown-linebreak-ext=md
+
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.43.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_docs

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
+MAKEFILES_VER := v0.1.1
 
 help:
 	@echo 'Available Commands:'
@@ -13,7 +14,8 @@ help:
 init-makefiles: ## initialize makefiles
 	rm -rf ${MAKEFILES_DIR}
 	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
+	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR} -q
+	cd ${MAKEFILES_DIR} && git checkout ${MAKEFILES_VER} -q
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk

--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ Personally we have seen the need of creating a similar set of such resources
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| key\_pair\_name | Key Pair Name | `string` | n/a | yes |
-| name | Name | `string` | n/a | yes |
-| subnet\_id | Subnet ID | `string` | n/a | yes |
-| vpc\_id | VPC ID | `string` | n/a | yes |
 | ami\_id | AMI Identifier | `string` | `""` | no |
 | associate\_public\_ip\_address | Associate a public IP address with the instance | `bool` | `false` | no |
 | aws\_ami\_os\_id | AWS AMI Operating System Identificator | `string` | `"ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"` | no |
@@ -66,16 +62,20 @@ Personally we have seen the need of creating a similar set of such resources
 | ephemeral\_block\_device | Customize Ephemeral (also known as Instance Store) volumes on the instance | `list(map(string))` | `[]` | no |
 | instance\_profile | The IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. | `string` | `""` | no |
 | instance\_type | EC2 Instance Type | `string` | `"t3.micro"` | no |
+| key\_pair\_name | Key Pair Name | `string` | n/a | yes |
 | monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
+| name | Name | `string` | n/a | yes |
 | policy\_arn | Attach AWS IAM managed policies to the IAM Role. | `list(string)` | `[]` | no |
 | prefix | Prefix | `string` | `"default"` | no |
 | root\_block\_device | Customize details about the root block device of the instance. See Block Devices below for details | `list(map(string))` | `[]` | no |
 | root\_device\_backup\_tag | EC2 Root Block Device backup tag | `string` | `"True"` | no |
 | security\_group\_rules | A list of security group rules | `list(any)` | `[]` | no |
-| tagApprovedAMIvalue | Set the specific tag ApprovedAMI ('true' \| 'false') that identifies aws-config compliant AMIs | `string` | `"false"` | no |
+| subnet\_id | Subnet ID | `string` | n/a | yes |
+| tag\_approved\_ami\_value | Set the specific tag ApprovedAMI ('true' \| 'false') that identifies aws-config compliant AMIs | `string` | `"false"` | no |
 | tags | Tags | `map(string)` | `{}` | no |
 | user\_data | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user\_data\_base64 instead. | `string` | `null` | no |
 | user\_data\_base64 | Can be used instead of user\_data to pass base64-encoded binary data directly. Use this instead of user\_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. | `string` | `null` | no |
+| vpc\_id | VPC ID | `string` | n/a | yes |
 
 ## Outputs
 


### PR DESCRIPTION
## What?
#### Commits on Nov 13, 2020
- @exequielrafaela - BBL-440 | makefile lib ver approach added + pre-commit for ci - 407701c
- @exequielrafaela - BBL-440 | fixing circleci/config.yml sintaxt - 60faf8e
- @exequielrafaela - BBL-440 | adding missing terraform-docs binary dep - b70f67c
- @exequielrafaela - BBL-440 | fixing terraform-docs installation - 6c51f5c
- @exequielrafaela - BBL-440 | updating mv with sudo + temporally disabling terratest jobs - 2213430
- @exequielrafaela - BBL-440 | adding terraform binary for pre-commit exec - 1e7c3b6
- @exequielrafaela - BBL-440 | re-enabling terratest - 9ceff3e

## Why?
- https://trello.com/c/of2uWKqa/444-bbl-444-pm-create-tasks-for-attached-29-10-2020-review-meeting
- https://trello.com/c/LZgL7qCF/440-bbl-440-add-cross-repo-clone-with-tag-for-make-init-makefiles

### Validation
![image](https://user-images.githubusercontent.com/18539704/99079516-d5629400-259e-11eb-8c60-35ab7d088096.png)