### PR TITLE
Replace map function which is no longer supported in Terraform v1.x

### DIFF
--- a/instances.tf
+++ b/instances.tf
@@ -77,7 +77,7 @@ resource "aws_instance" "main" {
     }
   }
 
-  volume_tags = merge(var.tags, map("Backup", var.root_device_backup_tag))
+  volume_tags = merge(var.tags, { "Backup" = var.root_device_backup_tag })
   tags        = var.tags
 
   lifecycle {


### PR DESCRIPTION
## what
* Replace map function which is no longer supported in Terraform v1.x

## why
* Otherwise Terraform v1.x complains about using the deprecated function
