### PR TITLE
SSM flag for SSM policy attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ No modules.
 | [aws_iam_policy.cross_org_instance_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.basic_instance_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.basic_instance_aws_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ec2_ssm_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_route53_record.main_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -83,6 +84,7 @@ No modules.
 | <a name="input_dns_records_public_hosted_zone"></a> [dns\_records\_public\_hosted\_zone](#input\_dns\_records\_public\_hosted\_zone) | A list of DNS public (public hosted zone) records to create with the instance's IP | `list(any)` | `[]` | no |
 | <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | Enable EBS Optimized | `string` | `"false"` | no |
+| <a name="input_enable_ssm_access"></a> [enable\_ssm\_access](#input\_enable\_ssm\_access) | If true, attaches SSM policy to instance role | `string` | `"false"` | no |
 | <a name="input_ephemeral_block_device"></a> [ephemeral\_block\_device](#input\_ephemeral\_block\_device) | Customize Ephemeral (also known as Instance Store) volumes on the instance | `list(map(string))` | `[]` | no |
 | <a name="input_instance_profile"></a> [instance\_profile](#input\_instance\_profile) | The IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 Instance Type | `string` | `"t3.micro"` | no |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ No modules.
 | <a name="input_dns_records_public_hosted_zone"></a> [dns\_records\_public\_hosted\_zone](#input\_dns\_records\_public\_hosted\_zone) | A list of DNS public (public hosted zone) records to create with the instance's IP | `list(any)` | `[]` | no |
 | <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | Enable EBS Optimized | `string` | `"false"` | no |
-| <a name="input_enable_ssm_access"></a> [enable\_ssm\_access](#input\_enable\_ssm\_access) | If true, attaches SSM policy to instance role | `string` | `"false"` | no |
+| <a name="input_enable_ssm_access"></a> [enable\_ssm\_access](#input\_enable\_ssm\_access) | If true, attaches SSM policy to instance role | `bool` | `false` | no |
 | <a name="input_ephemeral_block_device"></a> [ephemeral\_block\_device](#input\_ephemeral\_block\_device) | Customize Ephemeral (also known as Instance Store) volumes on the instance | `list(map(string))` | `[]` | no |
 | <a name="input_instance_profile"></a> [instance\_profile](#input\_instance\_profile) | The IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 Instance Type | `string` | `"t3.micro"` | no |

--- a/security.tf
+++ b/security.tf
@@ -112,3 +112,10 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
     sid = "ec2AssumeRoleCrossAccountStatementID"
   }
 }
+
+# SSM Policy
+resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
+  count      = var.enable_ssm_access == "" ? 1 : 0
+  role       = aws_iam_role.basic_instance_assume_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}

--- a/security.tf
+++ b/security.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 
 # SSM Policy
 resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
-  count      = var.enable_ssm_access == "" ? 1 : 0
+  count      = var.enable_ssm_access ? 1 : 0
   role       = aws_iam_role.basic_instance_assume_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
 }

--- a/security.tf
+++ b/security.tf
@@ -117,5 +117,5 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
   count      = var.enable_ssm_access == "" ? 1 : 0
   role       = aws_iam_role.basic_instance_assume_role[0].name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -167,3 +167,9 @@ variable "disable_api_termination" {
   description = "If true, enables EC2 Instance Termination Protection"
   default     = "false"
 }
+
+variable "enable_ssm_access" {
+  type        = string
+  description = "If true, attaches SSM policy to instance role"
+  default     = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -169,7 +169,7 @@ variable "disable_api_termination" {
 }
 
 variable "enable_ssm_access" {
-  type        = string
+  type        = bool
   description = "If true, attaches SSM policy to instance role"
-  default     = "false"
+  default     = false
 }


### PR DESCRIPTION
## what
* Added an SSM flag to attach [AmazonSSMManagedInstanceCore](https://aws.amazon.com/blogs/mt/applying-managed-instance-policy-best-practices/) to the instance profile
* This flag can be toggled by setting `enable_ssm_access` to true in `locals.tf` (default is false)

## why
* It's an easy and practical way of integrating SSM policies to EC2 module.
* It eliminates the necessity of having the user of the module, type the actual policy to attach.
* It ensures we keep up to date with AWS managed policies best practices.

## references
* [AWS SSM doc](https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-instance-profile.html)


