### PR TITLE
changed count formula and added proper managed policy

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 
 # SSM Policy
 resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
-  count      = var.enable_ssm_access ? 1 : 0
+  count      = var.enable_ssm_access == true ? 1 : 0
   role       = aws_iam_role.basic_instance_assume_role[0].name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }


### PR DESCRIPTION
## what
* Changing the policy (adding the correct one for EC2 instances).
* Modifying the count formula in the resource creation.

## why
* Terraform was having issues reading the boolean variable.
* Previous policy was for IAM users and not for resources.
