### PR TITLE
Fix: enabling SSM access when a profile is passed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
 # configuration elements, including jobs, commands, and executors.
 #
 orbs:
-  sumologic: circleci/sumologic@1.0.6
+  # sumologic: circleci/sumologic@1.0.6
   slack: circleci/slack@4.1.1
 
 #
@@ -296,5 +296,5 @@ workflows:
             branches:
              only: # only branches matching the below regex filters will run
                - master
-      - sumologic/workflow-collector:
-          context: binbashar-org-global-context
+      # - sumologic/workflow-collector:
+      #     context: binbashar-org-global-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,123 @@ jobs:
 
       - run:
           name: test-terraform-linting
-          command: make tflint-deep
+          command: make tflint
+
+      - slack/notify:
+          event: fail
+          mentions: '@leverage-support'
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Failed Pipeline! :rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":negative_squared_cross_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *User*: $CIRCLE_USERNAME \n :negative_squared_cross_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *Branch:* $CIRCLE_BRANCH \n :negative_squared_cross_mark: *PR:* $CIRCLE_PULL_REQUEST \n :negative_squared_cross_mark: *Last Commit:* $CIRCLE_SHA1"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job in CircleCi",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
+          channel: 'tools-ci'
+      - slack/notify:
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Successful Pipeline! :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :tada: :binbash::bb-leverage: :heart: :open-source:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":heavy_check_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *User*: $CIRCLE_USERNAME \n :heavy_check_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *Branch:* $CIRCLE_BRANCH \n :heavy_check_mark: *PR:* $CIRCLE_PULL_REQUEST \n :heavy_check_mark: *Last Commit:* $CIRCLE_SHA1"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job in CircleCi",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
+          channel: 'tools-ci'
+
+  #
+  # Tests E2E
+  #
+  test-e2e-terratests:
+    machine:
+      image: ubuntu-2004:202107-01
+      docker_layer_caching: false
+
+    steps:
+      - checkout
+
+      - run:
+          name: Context Info Cmds
+          command: pwd && ls -ltra && git branch
+
+      - run:
+          name: Initialize Repo Makefiles
+          command: |
+            make init-makefiles
+            git update-index --assume-unchanged "Makefile"
+
+      - run:
+          name: Install awscli
+          command: sudo -H pip3 install awscli
+
+      - run:
+          name: Configure awscli
+          command: |
+            # AWS defautl awscli profile
+            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+            aws configure set region us-east-1
+            aws configure set output json
+
+            # AWS dev awscli profile
+            aws configure set role_arn arn:aws:iam::$AWS_ACCOUNT_ID_SHARED:role/DeployMaster --profile $AWS_PROFILE_NAME
+            aws configure set source_profile default --profile $AWS_PROFILE_NAME
+            # moving credentials to specific project folder
+            mkdir --parents /home/circleci/.aws/bb
+            cp /home/circleci/.aws/credentials /home/circleci/.aws/bb/credentials
+            cp /home/circleci/.aws/config /home/circleci/.aws/bb/config
+
+      - run:
+          name: Test AWS permissions
+          command: aws ec2 describe-instances --region us-east-1 --profile $AWS_PROFILE_NAME
 
       - run:
           name: test-terratests-dep-init
@@ -288,8 +404,14 @@ workflows:
           context: binbashar-org-global-context
           filters:
             branches:
-              ignore: # only branches matching the below regex filters will run
-                - master
+             ignore: # only branches matching the below regex filters will run
+               - master
+      - test-e2e-terratests:
+          context: binbashar-org-global-context
+          filters:
+            branches:
+             ignore: # only branches matching the below regex filters will run
+               - master
       - release-version-with-changelog:
           context: binbashar-org-global-context
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v0.3.32"></a>
+## [v0.3.32] - 2022-10-08
+
+- Update README.md
+
+
 <a name="v0.3.31"></a>
 ## [v0.3.31] - 2022-05-25
 
@@ -292,7 +298,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/binbashar/terraform-aws-ec2-basic-layout/compare/v0.3.31...HEAD
+[Unreleased]: https://github.com/binbashar/terraform-aws-ec2-basic-layout/compare/v0.3.32...HEAD
+[v0.3.32]: https://github.com/binbashar/terraform-aws-ec2-basic-layout/compare/v0.3.31...v0.3.32
 [v0.3.31]: https://github.com/binbashar/terraform-aws-ec2-basic-layout/compare/v0.3.30...v0.3.31
 [v0.3.30]: https://github.com/binbashar/terraform-aws-ec2-basic-layout/compare/v0.3.29...v0.3.30
 [v0.3.29]: https://github.com/binbashar/terraform-aws-ec2-basic-layout/compare/v0.3.28...v0.3.29

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.1.33
+MAKEFILES_VER := v0.2.16
 
 help:
 	@echo 'Available Commands:'
@@ -19,7 +19,6 @@ init-makefiles: ## initialize makefiles
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk
--include ${MAKEFILES_DIR}/terraform14/terraform14-root-context.mk
--include ${MAKEFILES_DIR}/terraform14/terraform14.mk
--include ${MAKEFILES_DIR}/terratest14/terratest14.mk
-
+-include ${MAKEFILES_DIR}/terraform1/terraform1-root-context.mk
+-include ${MAKEFILES_DIR}/terraform1/terraform1.mk
+-include ${MAKEFILES_DIR}/terratest1/terratest1.mk

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ In order to get the full automated potential of the
 you should initialize all the necessary helper **Makefiles**.
 
 #### How?
-You must execute the `make init-makefiles` command  at the root context
+You must execute the `make init-makefiles` command  at the root context:
 
 ```shell
 ╭─delivery at delivery-I7567 in ~/terraform/terraform-aws-backup-by-tags on master✔ 20-09-17

--- a/security.tf
+++ b/security.tf
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 # Attach the AmazonSSMManagedInstanceCore policy to the instance role
 # If instance_role is not provided, attach the policy to the basic_instance role
 resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
-  count = var.enable_ssm_access == "" ? 1 : 0
+  count      = var.enable_ssm_access == "" ? 1 : 0
   role       = var.instance_profile == "" ? aws_iam_role.basic_instance_assume_role[0].name : var.instance_profile
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }

--- a/security.tf
+++ b/security.tf
@@ -114,8 +114,11 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 }
 
 # SSM Policy
+# Attach the AmazonSSMManagedInstanceCore policy to the instance role
+# If instance_role is not provided, attach the policy to the basic_instance role
 resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
-  count      = var.enable_ssm_access == true ? 1 : 0
-  role       = aws_iam_role.basic_instance_assume_role[0].name
+  count = var.enable_ssm_access == "" ? 1 : 0
+  role       = var.instance_profile == "" ? aws_iam_role.basic_instance_assume_role[0].name : var.instance_profile
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+


### PR DESCRIPTION
## what
It fixes the bug #35 while enabling SSM access and passing an `instance_profile` value. 

## why
When the `instance_profile` was provided and `enable_ssm_access` was set to true, the resource `aws_iam_role_policy_attachment.ec2_ssm_access` tried to attach the managed policy `AmazonSSMManagedInstanceCore` to a non existing role `basic_instance_assume_role`, which is only created when the `instance_profile` is empty.

## references
* closes #35 

