### PR TITLE
Add support for passing existing Security Group IDs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,9 +273,9 @@ jobs:
 # CircleCI orbs are open-source, shareable packages of parameterizable reusable
 # configuration elements, including jobs, commands, and executors.
 #
-orbs:
-  sumologic: circleci/sumologic@1.0.6
-  slack: circleci/slack@4.1.1
+# orbs:
+#   sumologic: circleci/sumologic@1.0.6
+#   slack: circleci/slack@4.1.1
 
 #
 # Jobs workflow
@@ -296,5 +296,5 @@ workflows:
             branches:
              only: # only branches matching the below regex filters will run
                - master
-      - sumologic/workflow-collector:
-          context: binbashar-org-global-context
+      # - sumologic/workflow-collector:
+      #     context: binbashar-org-global-context

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ No modules.
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix | `string` | `"default"` | no |
 | <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | Customize details about the root block device of the instance. See Block Devices below for details | `list(map(string))` | `[]` | no |
 | <a name="input_root_device_backup_tag"></a> [root\_device\_backup\_tag](#input\_root\_device\_backup\_tag) | EC2 Root Block Device backup tag | `string` | `"True"` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group ids | `list(string)` | `[]` | no |
 | <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of security group rules | `list(any)` | `[]` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID | `string` | n/a | yes |
 | <a name="input_tag_approved_ami_value"></a> [tag\_approved\_ami\_value](#input\_tag\_approved\_ami\_value) | Set the specific tag ApprovedAMI ('true' \| 'false') that identifies aws-config compliant AMIs | `string` | `"false"` | no |

--- a/instances.tf
+++ b/instances.tf
@@ -27,7 +27,7 @@ data "aws_ami" "ubuntu_linux" {
 resource "aws_instance" "main" {
   ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.ubuntu_linux.id
   instance_type               = var.instance_type
-  vpc_security_group_ids      = [aws_security_group.main.id]
+  vpc_security_group_ids      = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.main[0].id]
   subnet_id                   = var.subnet_id
   key_name                    = var.key_pair_name
   iam_instance_profile        = var.instance_profile == "" ? aws_iam_instance_profile.basic_instance[0].id : var.instance_profile

--- a/security.tf
+++ b/security.tf
@@ -2,6 +2,7 @@
 # Security Groups
 #
 resource "aws_security_group" "main" {
+  count       = length(var.security_group_rules) > 0 ? 1 : 0
   name        = "${var.prefix}-${var.name}-instance"
   description = "${title(var.name)} Security Group Rules"
   vpc_id      = var.vpc_id
@@ -20,20 +21,21 @@ resource "aws_security_group_rule" "ingress_rules" {
   protocol          = lookup(element(var.security_group_rules, count.index), "protocol", "tcp")
   cidr_blocks       = lookup(element(var.security_group_rules, count.index), "cidr_blocks", "0.0.0.0/0")
   description       = lookup(element(var.security_group_rules, count.index), "description", "")
-  security_group_id = aws_security_group.main.id
+  security_group_id = aws_security_group.main[0].id
 }
 
 #
 # Security Groups Egress Rules
 #
 resource "aws_security_group_rule" "egress_allow_all" {
+  count             = length(var.security_group_rules) > 0 ? 1 : 0
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "Allow Egress All"
-  security_group_id = aws_security_group.main.id
+  security_group_id = aws_security_group.main[0].id
 }
 
 #
@@ -42,14 +44,14 @@ resource "aws_security_group_rule" "egress_allow_all" {
 resource "aws_iam_instance_profile" "basic_instance" {
   count = var.instance_profile == "" ? 1 : 0
 
-  name = "basic-instance-profile-${var.prefix}-${var.name}"
+  name = "${var.prefix}-${var.name}"
   role = aws_iam_role.basic_instance_assume_role[0].name
 }
 
 resource "aws_iam_role" "basic_instance_assume_role" {
   count = var.instance_profile == "" ? 1 : 0
 
-  name               = "basic-instance-role-${var.prefix}-${var.name}"
+  name               = "${var.prefix}-${var.name}"
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.this.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -144,6 +144,12 @@ variable "security_group_rules" {
   default     = []
 }
 
+variable "security_group_ids" {
+  type        = list(string)
+  description = "A list of security group ids"
+  default     = []
+}
+
 variable "dns_records_internal_hosted_zone" {
   type        = list(any)
   description = "A list of DNS private (internal hosted zone) records to create with the instance's IP"


### PR DESCRIPTION
## what
* Add support for passing existing Security Group IDs.

## why
* Currently the module creates its own security group using the rules you provide but it some cases it is necessary to use existing security groups for the instance you intend to provision.

## references
N/A