### PR TITLE
Fix missing Slack Orb when running the release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,9 +273,9 @@ jobs:
 # CircleCI orbs are open-source, shareable packages of parameterizable reusable
 # configuration elements, including jobs, commands, and executors.
 #
-# orbs:
+orbs:
 #   sumologic: circleci/sumologic@1.0.6
-#   slack: circleci/slack@4.1.1
+  slack: circleci/slack@4.1.1
 
 #
 # Jobs workflow


### PR DESCRIPTION
## what
* Fix missing Slack Orb when running the release workflow.

## why
* I removed this by mistake on a previous PR.

## references
N/A