### PR TITLE
Fix an issue with the condition used to attach the SSM policy to the …

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -119,8 +119,7 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 # Attach the AmazonSSMManagedInstanceCore policy to the instance role
 # If instance_role is not provided, attach the policy to the basic_instance role
 resource "aws_iam_role_policy_attachment" "ec2_ssm_access" {
-  count      = var.enable_ssm_access == "" ? 1 : 0
+  count      = var.enable_ssm_access == true ? 1 : 0
   role       = var.instance_profile == "" ? aws_iam_role.basic_instance_assume_role[0].name : var.instance_profile
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
-


### PR DESCRIPTION
…instance

## what
* Fix an issue with the condition used to attach the SSM policy to the EC2 instance

## why
* The conditional was comparing against the wrong variable type (boolean vs string) causing the SSM policy to never be attached to the instance even when passing a "true" in said variable.

## references
N/A

